### PR TITLE
Fix subclassing Redtape::Form twice.

### DIFF
--- a/lib/redtape.rb
+++ b/lib/redtape.rb
@@ -1,6 +1,7 @@
 require "redtape/version"
 
 require 'active_model'
+require 'active_support/core_ext/class/attribute'
 
 module Redtape
   class Form
@@ -8,13 +9,12 @@ module Redtape
     include ActiveModel::Conversion
     include ActiveModel::Validations
 
-    attr_accessor :model_accessors
-
     validate :models_correct
+    class_attribute :model_accessors
 
     def self.validates_and_saves(*args)
       attr_accessor *args
-      @@model_accessors = args
+      self.model_accessors = args
     end
 
     def initialize(attrs = {})
@@ -25,7 +25,7 @@ module Redtape
 
     def models_correct
       populate
-      @@model_accessors.each do |accessor|
+      self.class.model_accessors.each do |accessor|
         begin
           model = send(accessor)
           if model.invalid?
@@ -51,7 +51,7 @@ module Redtape
     end
 
     def persist!
-      @@model_accessors.each do |accessor|
+      self.class.model_accessors.each do |accessor|
         model = send(accessor)
         unless model.save
           return false

--- a/redtape.gemspec
+++ b/redtape.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "debugger"
 
   gem.add_runtime_dependency "activemodel"
+  gem.add_runtime_dependency "activesupport"
 end

--- a/spec/form_spec.rb
+++ b/spec/form_spec.rb
@@ -112,4 +112,23 @@ describe Redtape::Form do
     end
   end
 
+  context "given another Form subclass" do
+    before do
+      Class.new(Redtape::Form) do
+        validates_and_saves :test_object
+      end.new(:test_object => :foo)
+    end
+
+    subject {
+      TestRegistrationForm.new
+    }
+
+    context "TestRegistrationForm still saves User" do
+      before do
+        subject.save
+      end
+
+      specify { subject.should_not be_valid }
+    end
+  end
 end


### PR DESCRIPTION
Without this fix subclassing `Redtape::Form` twice
would overwrite `model_accessors` in the base class.

Example:

```
class Signup < Redtape::Form
  validates_and_saves :user
end

class WelcomePost < Redtape::Form
  validates_and_saves :post
end

WelcomePost.new(params[:post]).save # works
Signup.new(params[:user]).save      # breaks
```

`Signup` would break because `model_accessors` is overwritten with
`post`.
