### PR TITLE
Separate methods for instantiating form and assigning values

### DIFF
--- a/lib/redtape.rb
+++ b/lib/redtape.rb
@@ -21,10 +21,11 @@ module Redtape
       attrs.each do |k, v|
         send("#{k}=", v)
       end
+
+      populate
     end
 
     def models_correct
-      populate
       self.class.model_accessors.each do |accessor|
         begin
           model = send(accessor)
@@ -62,6 +63,15 @@ module Redtape
 
     def populate
       fail NotImplementedError, "Implement #populate in your subclass"
+    end
+
+    def assign_values(attrs = {})
+      attrs.each do |k, v|
+        send("#{k}=", v)
+      end
+
+      assign
+      self
     end
 
     private


### PR DESCRIPTION
I might be missing something, but it didn't make sense to me to have a single populate method. For me, I want to populate the form object with existing data (if any) for the new/edit actions, and I want to assign the form values to the underlying objects on create/update. Essentially, they are opposite functions.

I added an `assign_values` method so that is used in the create/update actions. In the subclass, the user writes an assign method. Here's an example:

``` ruby
# quality_checks_controller.rb
def edit
  user = User.find(params[:id])
  @form = QualityCheckForm.new(user: user)
end

def update
  @form = QualityCheckForm.new(user: user).assign_values(params[:quality_check_form])
  if @form.save
    # happy path
  else
    # sad path
  end
end

# quality_check_form.rb
def populate
  address = user.address
  account = user.account

  self.line_1 = address.line_1
  self.city = address.city
  self.state = address.state
  self.zip = address.zip

  self.acct_number = account.acct_number
  self.balance = account.balance
end

def assign
  address.line_1 = self.line_1.titelize
  address.city = self.city
  address.state = self.state
  address.zip = self.zip

  account.acct_number = self.acct_number.to_i
  account.balance = self.balance.to_f
end
```

Does this make sense, or am I doing it wrong?
