### PR TITLE
Fix tests for some rubies on Travis.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
   gem 'virtus'
   gem 'rspec'
   gem 'rails'
+  gem 'pry'
 
   platform :ruby do
     gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem 'minitest'
   gem 'virtus'
   gem 'rspec'
   gem 'rails'

--- a/redtape.gemspec
+++ b/redtape.gemspec
@@ -15,11 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Redtape::VERSION
 
-  gem.add_development_dependency "virtus"
-  gem.add_development_dependency "rails"
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "sqlite3"
-  gem.add_development_dependency "pry"
+  # See Gemfile for development dependencies.
 
   gem.add_runtime_dependency "activemodel"
   gem.add_runtime_dependency "activesupport"


### PR DESCRIPTION
https://travis-ci.org/ClearFit/redtape/builds/3442789

I've moved development dependencies to `Gemfile` to fix tests for JRuby (sqlite3) again.

ActiveSupport depends on `minitest`.
Either we add a dependency or we drop 1.8 support.

What do you think?
